### PR TITLE
change remove_cv_t to remove_cv

### DIFF
--- a/app/views/d3_contests/division_3.html.erb
+++ b/app/views/d3_contests/division_3.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
     <h4>Qu'est ce que c'est ?</h4>
-    <p>Le Championnat de France des clubs féminins et masculins de 3ème Division de Triathlon se dispute sous la formule d’élimination directe sur 3 niveaux : Sélection régionale, Demi-Finale par zone (Nord, Nord-Est, Sud-Est, Sud-Ouest, Centre-Ouest) et finale. La Finale réunit l’ensemble des clubs qualifiés à l’issue de ½ finales de zone.</p>
+    <p>Le Championnat de France des clubs féminins et masculins de 3ème Division de Triathlon se dispute sous la formule d’élimination directe sur 3 niveaux : Sélection régionale, Demi-Finale par zone (Nord, Nord-Est, Sud-Est, Sud-Ouest, Centre-Ouest) et finale. La Finale réunit l’ensemble des clubs qualifiés à l’issue de ½ finales de zone. </p>
 
   <div class="col-sm-12 col-md-6">
     <div class="d3-team">


### PR DESCRIPTION
Using this solution
https://stackoverflow.com/questions/67241196/error-no-template-named-remove-cv-t-in-namespace-std-did-you-mean-remove

I was getting this error while building node-sass.

/Users/shahwarkhalid/.node-gyp/16.6.1/include/node/v8-internal.h:488:38: error: no template named 'remove_cv_t' in namespace 'std'; did you mean 'remove_cv'?

This hack solved my issue:

cd /Users/shahwarkhalid/.node-gyp/16.6.1/include/node/

open v8-internal.h file in an editor.

change remove_cv_t to remove_cv on line 488.

yarn install again and the issue was resolved.